### PR TITLE
capture multiline error messages

### DIFF
--- a/Reason.py
+++ b/Reason.py
@@ -10,9 +10,9 @@ os.environ['PATH'] += ':/usr/local/bin/'
 # Portions Copyright (c) 2015-present, Facebook, Inc. All rights reserved.
 
 ERROR_RE = re.compile(
-    r'^File "(?P<file_name>.*)", line (?P<line>\d+), characters (?P<col>\d+)-\d+:$\r?\n'
+    r'^File "(?P<file_name>.*?)", line (?P<line>\d+), characters (?P<col>\d+)-\d+:$\r?\n'
     r'^Error: (?P<message>.+)$',
-    re.MULTILINE
+    re.MULTILINE|re.DOTALL
 )
 
 def is_interface(file_name):


### PR DESCRIPTION
The latest version of reason-cli has multiline error messages, but the linter plugin in this package only captures the first line, resulting in missing error info:

<img width="585" alt="screen shot 2017-06-21 at 7 20 52 pm" src="https://user-images.githubusercontent.com/1232587/27414702-c6e73066-56b7-11e7-84e7-e641f4300aa3.png">

This change captures the whole multiline error message. It's not perfect (because it puts the multiline error message on one line in the Sublime status bar), but it's more helpful than losing the subsequent lines.

Example: 
<img width="716" alt="screen shot 2017-06-21 at 7 20 24 pm" src="https://user-images.githubusercontent.com/1232587/27414722-e7dfacbc-56b7-11e7-86a5-def6decfef18.png">
