### PR TITLE
Avoid using the ambiguous \h shorthand character

### DIFF
--- a/Reason.JSON-tmLanguage
+++ b/Reason.JSON-tmLanguage
@@ -14,7 +14,7 @@
     {"include": "#reason_raw_string"},
     {
       "name": "string.quoted.single.source.reason",
-      "match": "\\'([^\\'\\\\]|\\\\(x\\h{2}|u\\{\\h{1,6}\\}|.))\\'"
+      "match": "\\'([^\\'\\\\]|\\\\(x[0-9A-Fa-f]{2}|u\\{[0-9A-Fa-f]{1,6}\\}|.))\\'"
     },
     {"name": "meta.function.source.reason",
      "match": "\\b(fun)\\s+([a-zA-Z_][a-zA-Z0-9_]?[\\w\\:,+ \\'<>?]*)\\s*(?:\\()",
@@ -147,7 +147,7 @@
   "repository": {
     "reason_escaped_character": {
       "name": "constant.character.escape.source.reason",
-      "match": "\\\\(x\\h{2}|u\\{\\h{1,6}\\}|.)"
+      "match": "\\\\(x[0-9A-Fa-f]{2}|u\\{[0-9A-Fa-f]{1,6}\\}|.)"
     },
     "reason_string": {
       "name": "string.quoted.double.source.reason",

--- a/Reason.tmLanguage
+++ b/Reason.tmLanguage
@@ -49,7 +49,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\'([^\'\\]|\\(x\h{2}|u\{\h{1,6}\}|.))\'</string>
+			<string>\'([^\'\\]|\\(x[0-9A-Fa-f]{2}|u\{[0-9A-Fa-f]{1,6}\}|.))\'</string>
 			<key>name</key>
 			<string>string.quoted.single.source.reason</string>
 		</dict>
@@ -373,7 +373,7 @@
 		<key>reason_escaped_character</key>
 		<dict>
 			<key>match</key>
-			<string>\\(x\h{2}|u\{\h{1,6}\}|.)</string>
+			<string>\\(x[0-9A-Fa-f]{2}|u\{[0-9A-Fa-f]{1,6}\}|.)</string>
 			<key>name</key>
 			<string>constant.character.escape.source.reason</string>
 		</dict>


### PR DESCRIPTION
Depending on the regular expression engine used, \h does not always
mean the same. With a PCRE engine, it matches white spaces, whereas,
with a Oniguruma engine, it matches hexademical digit characters.
Sublime Text uses an Oniguruma engine, but github.com relies on a
PCRE engine.