### PR TITLE
correct package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Language-server provides all the others (autocompletion, type hint, jump-to-defi
 The plugin's [published on Package Control](https://packagecontrol.io/packages/Reason).
 
 - Go to Command Palette (`cmd-shift-p`) -> Package Control: Install Package.
-- Choose sublime-reason.
+- Choose `Reason`.
 
 ## Language Server Installation
 


### PR DESCRIPTION
The sublime package comes up as "Reason" rather than "sublime-reason"

<img width="462" alt="screen shot 2018-08-24 at 11 00 29" src="https://user-images.githubusercontent.com/514563/44583964-a4240080-a7a7-11e8-9a0b-f74b6e8b5f60.png">
