### PR TITLE
Add support for commenting / uncommenting in bucklescript syntax

### DIFF
--- a/Comment.JSON-tmPreferences
+++ b/Comment.JSON-tmPreferences
@@ -1,5 +1,5 @@
 { "name": "Comments",
-  "scope": "source.reason",
+  "scope": "source.reason,source.bucklescript",
   "settings": {
     "shellVariables": [{"name": "TM_COMMENT_START_2", "value": "// "},
                        {"name": "TM_COMMENT_DISABLE_INDENT", "value": "no"}

--- a/Comment.tmPreferences
+++ b/Comment.tmPreferences
@@ -5,7 +5,7 @@
 	<key>name</key>
 	<string>Comments</string>
 	<key>scope</key>
-	<string>source.reason</string>
+	<string>source.reason,source.bucklescript</string>
 	<key>settings</key>
 	<dict>
 		<key>shellVariables</key>


### PR DESCRIPTION
I'm no expert in sublime config files, but this seemed to allow me to comment/uncomment in Bucklescript syntax with the usual keybindings.